### PR TITLE
fix: Broken "Report an issue" hyperlink in footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An interactive web map of the [Tehaleh](https://www.tehaleh.com/) master-planned community in Bonney Lake, WA. Click any neighborhood polygon to see its name and details.
 
-> **Live site:** `https://farazromani.github.io/tehaleh-neighborhood-map/`
+**Live site:** [https://farazromani.github.io/tehaleh-neighborhood-map](https://farazromani.github.io/tehaleh-neighborhood-map)
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
   <footer class="site-footer">
     <p>Tehaleh is a master-planned community in unincorporated Pierce County, WA &mdash; developed by Newland.</p>
     <p class="footer-note">Neighborhood boundaries are approximate. This is a community fan project, not affiliated with Newland or Tehaleh.</p>
-    <p class="footer-note">Found a mistake or missing neighborhood? <a class="footer-link" href="https://github.com/YOUR_USERNAME/tehaleh-map/issues/new" target="_blank" rel="noopener">Report an issue on GitHub</a></p>
+    <p class="footer-note">Found a mistake or missing neighborhood? <a class="footer-link" href="https://github.com/farazromani/tehaleh-neighborhood-map/issues/new" target="_blank" rel="noopener">Report an issue on GitHub</a></p>
   </footer>
 
   <!-- Leaflet JS -->


### PR DESCRIPTION
## Fix broken "Report an issue" footer link

This PR updates the "Report an issue" hyperlink in the footer of the main page so it routes to the correct GitHub issue creation page for this repository.

### Problem
The existing footer link contained a placeholder username and did not direct users to the correct destination. As a result, users were unable to report issues directly from the site.

### Solution
- Updated the footer hyperlink in `index.html`
- Replaced the placeholder URL with the correct repository issues link:
  `https://github.com/farazromani/tehaleh-neighborhood-map/issues/new`
- Verified that the link opens the GitHub new issue page in a new tab

### Result
Users can now successfully report issues directly from the footer of the site.

Closes #1 